### PR TITLE
Pjs presets

### DIFF
--- a/presets/factory/pjs_drum_brain-v1.json
+++ b/presets/factory/pjs_drum_brain-v1.json
@@ -1,0 +1,82 @@
+{
+    "preset_info": {
+        "name": "Drum Brain v1",
+            "version": "1.0",
+                "author": "Pekko",
+                    "description": "16-neuron kick/snare/hat/fx brain with light inhibition and groove links",
+                        "created_date": "2025-10-30T00:00:00Z",
+                            "tags": "drums,generative,neural",
+                                "neuron_count": 16,
+                                    "connection_count": 29
+    },
+    "neurons": [
+        { "id": 0, "sample_index": 1, "activation": 0.0, "threshold": 0.58, "decay_rate": 0.92, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 1, "sample_index": 2, "activation": 0.0, "threshold": 0.60, "decay_rate": 0.93, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 2, "sample_index": 3, "activation": 0.0, "threshold": 0.63, "decay_rate": 0.93, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 3, "sample_index": 4, "activation": 0.0, "threshold": 0.62, "decay_rate": 0.94, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+
+        { "id": 4, "sample_index": 5, "activation": 0.0, "threshold": 0.64, "decay_rate": 0.92, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 5, "sample_index": 6, "activation": 0.0, "threshold": 0.66, "decay_rate": 0.92, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 6, "sample_index": 7, "activation": 0.0, "threshold": 0.56, "decay_rate": 0.90, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 7, "sample_index": 8, "activation": 0.0, "threshold": 0.70, "decay_rate": 0.93, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+
+        { "id": 8, "sample_index": 9, "activation": 0.0, "threshold": 0.50, "decay_rate": 0.88, "activation_increase_per_iteration": 0.0, "activation_function": "ReLU" },
+        { "id": 9, "sample_index": 10, "activation": 0.0, "threshold": 0.52, "decay_rate": 0.88, "activation_increase_per_iteration": 0.0, "activation_function": "ReLU" },
+        { "id": 10, "sample_index": 11, "activation": 0.0, "threshold": 0.48, "decay_rate": 0.87, "activation_increase_per_iteration": 0.0, "activation_function": "ReLU" },
+        { "id": 11, "sample_index": 12, "activation": 0.0, "threshold": 0.53, "decay_rate": 0.89, "activation_increase_per_iteration": 0.0, "activation_function": "ReLU" },
+
+        { "id": 12, "sample_index": 13, "activation": 0.0, "threshold": 0.72, "decay_rate": 0.95, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 13, "sample_index": 14, "activation": 0.0, "threshold": 0.70, "decay_rate": 0.95, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 14, "sample_index": 15, "activation": 0.0, "threshold": 0.74, "decay_rate": 0.96, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 15, "sample_index": 16, "activation": 0.0, "threshold": 0.76, "decay_rate": 0.96, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" }
+    ],
+        "connections": [
+            { "source_id": 1, "target_id": 5, "weight": 0.35 },
+            { "source_id": 5, "target_id": 6, "weight": 0.25 },
+            { "source_id": 5, "target_id": 7, "weight": -0.20 },
+
+            { "source_id": 8, "target_id": 9, "weight": 0.15 },
+            { "source_id": 9, "target_id": 8, "weight": 0.15 },
+            { "source_id": 10, "target_id": 11, "weight": 0.15 },
+            { "source_id": 11, "target_id": 10, "weight": 0.15 },
+
+            { "source_id": 5, "target_id": 8, "weight": -0.25 },
+            { "source_id": 5, "target_id": 9, "weight": -0.25 },
+            { "source_id": 5, "target_id": 10, "weight": -0.25 },
+            { "source_id": 5, "target_id": 11, "weight": -0.25 },
+
+            { "source_id": 3, "target_id": 12, "weight": 0.25 },
+            { "source_id": 7, "target_id": 13, "weight": 0.25 },
+            { "source_id": 11, "target_id": 14, "weight": 0.15 },
+
+            { "source_id": 15, "target_id": 8, "weight": -0.35 },
+            { "source_id": 15, "target_id": 9, "weight": -0.35 },
+            { "source_id": 15, "target_id": 10, "weight": -0.35 },
+            { "source_id": 15, "target_id": 11, "weight": -0.35 },
+
+            { "source_id": 0, "target_id": 1, "weight": -0.10 },
+            { "source_id": 1, "target_id": 2, "weight": -0.10 },
+            { "source_id": 2, "target_id": 3, "weight": -0.10 },
+            { "source_id": 4, "target_id": 5, "weight": -0.10 },
+            { "source_id": 6, "target_id": 7, "weight": -0.10 },
+            { "source_id": 8, "target_id": 10, "weight": -0.10 },
+            { "source_id": 9, "target_id": 11, "weight": -0.10 },
+
+            { "source_id": 0, "target_id": 4, "weight": 0.20 },
+            { "source_id": 2, "target_id": 6, "weight": 0.15 },
+            { "source_id": 12, "target_id": 15, "weight": 0.10 },
+            { "source_id": 5, "target_id": 12, "weight": 0.10 }
+        ],
+            "rhythmogram_matrix": {
+        "enabled": true,
+            "scale": 5.0,
+                "filter_gains": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+    },
+    "quantization": {
+        "enabled": true,
+            "grid_resolution": "sixteenth_note",
+                "quantization_amount": 0.65,
+                    "swing_factor": 0.58,
+                        "bpm": 120.0
+    }
+}

--- a/presets/factory/pjs_drum_brain_4.json
+++ b/presets/factory/pjs_drum_brain_4.json
@@ -1,0 +1,103 @@
+{
+    "preset_info": {
+        "name": "Drum Brain v1 (4-sample)",
+        "version": "1.0",
+        "author": "Pekko",
+        "description": "Compact 4-neuron drum brain using sample slots 1–4 (kick, snare, hat, fx)",
+        "created_date": "2025-10-30T00:00:00Z",
+        "tags": "drums,neural,compact",
+        "neuron_count": 4,
+        "connection_count": 6
+    },
+    "neurons": [
+        {
+            "id": 0,
+            "sample_index": 1,
+            "activation": 0.0,
+            "threshold": 0.58,
+            "decay_rate": 0.92,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 1,
+            "sample_index": 2,
+            "activation": 0.0,
+            "threshold": 0.64,
+            "decay_rate": 0.90,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 2,
+            "sample_index": 3,
+            "activation": 0.0,
+            "threshold": 0.52,
+            "decay_rate": 0.88,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "ReLU"
+        },
+        {
+            "id": 3,
+            "sample_index": 4,
+            "activation": 0.0,
+            "threshold": 0.70,
+            "decay_rate": 0.94,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        }
+    ],
+    "connections": [
+        {
+            "source_id": 0,
+            "target_id": 1,
+            "weight": 0.5
+        },
+        {
+            "source_id": 1,
+            "target_id": 2,
+            "weight": 0.4
+        },
+        {
+            "source_id": 2,
+            "target_id": 3,
+            "weight": 0.3
+        },
+        {
+            "source_id": 3,
+            "target_id": 0,
+            "weight": 0.2
+        },
+        {
+            "source_id": 1,
+            "target_id": 0,
+            "weight": -0.2
+        },
+        {
+            "source_id": 2,
+            "target_id": 1,
+            "weight": -0.2
+        }
+    ],
+    "rhythmogram_matrix": {
+        "enabled": true,
+        "scale": 5.0,
+        "filter_gains": [
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0
+        ]
+    },
+    "quantization": {
+        "enabled": true,
+        "grid_resolution": "sixteenth_note",
+        "quantization_amount": 0.7,
+        "swing_factor": 0.55,
+        "bpm": 120.0
+    }
+}

--- a/presets/factory/pjs_drum_brain_basic.json
+++ b/presets/factory/pjs_drum_brain_basic.json
@@ -1,0 +1,89 @@
+{
+    "preset_info": {
+        "name": "Drum Brain v1 (Basic Kit)",
+            "version": "1.0",
+                "author": "Pekko",
+                    "description": "16-neuron network using only basic drum kit slots (1–8). Multiple neurons per slot for groove variation.",
+                        "created_date": "2025-10-30T00:00:00Z",
+                            "tags": "drums,neural,basic-kit",
+                                "neuron_count": 16,
+                                    "connection_count": 33
+    },
+    "neurons": [
+        { "id": 0, "sample_index": 1, "activation": 0.22, "threshold": 0.58, "decay_rate": 0.92, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 1, "sample_index": 1, "activation": 0.18, "threshold": 0.62, "decay_rate": 0.93, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 2, "sample_index": 2, "activation": 0.12, "threshold": 0.64, "decay_rate": 0.92, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 3, "sample_index": 2, "activation": 0.08, "threshold": 0.66, "decay_rate": 0.92, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+
+        { "id": 4, "sample_index": 3, "activation": 0.04, "threshold": 0.50, "decay_rate": 0.88, "activation_increase_per_iteration": 0.0, "activation_function": "ReLU" },
+        { "id": 5, "sample_index": 3, "activation": 0.04, "threshold": 0.53, "decay_rate": 0.88, "activation_increase_per_iteration": 0.0, "activation_function": "ReLU" },
+        { "id": 6, "sample_index": 4, "activation": 0.02, "threshold": 0.48, "decay_rate": 0.87, "activation_increase_per_iteration": 0.0, "activation_function": "ReLU" },
+        { "id": 7, "sample_index": 4, "activation": 0.02, "threshold": 0.52, "decay_rate": 0.89, "activation_increase_per_iteration": 0.0, "activation_function": "ReLU" },
+
+        { "id": 8, "sample_index": 5, "activation": 0.00, "threshold": 0.60, "decay_rate": 0.90, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 9, "sample_index": 6, "activation": 0.00, "threshold": 0.70, "decay_rate": 0.94, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 10, "sample_index": 7, "activation": 0.00, "threshold": 0.72, "decay_rate": 0.94, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 11, "sample_index": 8, "activation": 0.00, "threshold": 0.76, "decay_rate": 0.96, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+
+        { "id": 12, "sample_index": 2, "activation": 0.05, "threshold": 0.56, "decay_rate": 0.90, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 13, "sample_index": 3, "activation": 0.03, "threshold": 0.47, "decay_rate": 0.86, "activation_increase_per_iteration": 0.0, "activation_function": "ReLU" },
+        { "id": 14, "sample_index": 1, "activation": 0.10, "threshold": 0.63, "decay_rate": 0.93, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 15, "sample_index": 8, "activation": 0.00, "threshold": 0.78, "decay_rate": 0.96, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" }
+    ],
+        "connections": [
+            { "source_id": 0, "target_id": 2, "weight": 0.30 },
+            { "source_id": 1, "target_id": 3, "weight": 0.35 },
+            { "source_id": 14, "target_id": 2, "weight": 0.25 },
+
+            { "source_id": 2, "target_id": 12, "weight": 0.25 },
+            { "source_id": 3, "target_id": 8, "weight": 0.20 },
+
+            { "source_id": 2, "target_id": 4, "weight": -0.25 },
+            { "source_id": 2, "target_id": 5, "weight": -0.25 },
+            { "source_id": 2, "target_id": 6, "weight": -0.20 },
+            { "source_id": 2, "target_id": 7, "weight": -0.20 },
+            { "source_id": 3, "target_id": 4, "weight": -0.20 },
+
+            { "source_id": 4, "target_id": 5, "weight": 0.12 },
+            { "source_id": 5, "target_id": 4, "weight": 0.12 },
+            { "source_id": 6, "target_id": 7, "weight": 0.12 },
+            { "source_id": 7, "target_id": 6, "weight": 0.12 },
+            { "source_id": 4, "target_id": 6, "weight": 0.10 },
+            { "source_id": 5, "target_id": 7, "weight": 0.10 },
+
+            { "source_id": 7, "target_id": 11, "weight": 0.15 },
+            { "source_id": 3, "target_id": 9, "weight": 0.25 },
+            { "source_id": 6, "target_id": 10, "weight": 0.20 },
+
+            { "source_id": 11, "target_id": 4, "weight": -0.35 },
+            { "source_id": 11, "target_id": 5, "weight": -0.35 },
+            { "source_id": 11, "target_id": 6, "weight": -0.35 },
+            { "source_id": 11, "target_id": 7, "weight": -0.35 },
+
+            { "source_id": 9, "target_id": 0, "weight": 0.10 },
+            { "source_id": 10, "target_id": 1, "weight": 0.10 },
+
+            { "source_id": 0, "target_id": 1, "weight": -0.10 },
+            { "source_id": 1, "target_id": 14, "weight": -0.10 },
+            { "source_id": 2, "target_id": 3, "weight": -0.10 },
+            { "source_id": 4, "target_id": 5, "weight": -0.10 },
+            { "source_id": 6, "target_id": 7, "weight": -0.10 },
+
+            { "source_id": 0, "target_id": 13, "weight": 0.15 },
+            { "source_id": 13, "target_id": 4, "weight": 0.10 },
+            { "source_id": 10, "target_id": 15, "weight": 0.20 },
+            { "source_id": 15, "target_id": 8, "weight": -0.20 }
+        ],
+            "rhythmogram_matrix": {
+        "enabled": true,
+            "scale": 5.0,
+                "filter_gains": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+    },
+    "quantization": {
+        "enabled": true,
+            "grid_resolution": "sixteenth_note",
+                "quantization_amount": 0.65,
+                    "swing_factor": 0.58,
+                        "bpm": 120.0
+    }
+}

--- a/presets/factory/pjs_fill_machine.json
+++ b/presets/factory/pjs_fill_machine.json
@@ -1,0 +1,361 @@
+{
+    "preset_info": {
+        "name": "Fill Machine (16)",
+        "version": "1.0",
+        "author": "Pekko",
+        "description": "Neuron roles: N0 Kick driver, N1 Kick alt, N2 Snare backbeat, N3 Snare ghost, N4 CHH A, N5 CHH B, N6 OHH breath, N7 OHH wash, N8 Rim/Clap, N9 Tom low, N10 Tom mid, N11 Crash tap, N12 Fill tom chain A, N13 Fill tom chain B, N14 Cym throw, N15 Brake (mutes hats before fills).",
+        "created_date": "2025-10-30T00:00:00Z",
+        "tags": "drums,fills,performance",
+        "neuron_count": 16,
+        "connection_count": 36
+    },
+    "neurons": [
+        {
+            "id": 0,
+            "sample_index": 1,
+            "activation": 0.22,
+            "threshold": 0.58,
+            "decay_rate": 0.92,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 1,
+            "sample_index": 1,
+            "activation": 0.14,
+            "threshold": 0.63,
+            "decay_rate": 0.93,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 2,
+            "sample_index": 2,
+            "activation": 0.12,
+            "threshold": 0.62,
+            "decay_rate": 0.92,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 3,
+            "sample_index": 2,
+            "activation": 0.06,
+            "threshold": 0.56,
+            "decay_rate": 0.90,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 4,
+            "sample_index": 3,
+            "activation": 0.05,
+            "threshold": 0.50,
+            "decay_rate": 0.88,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "ReLU"
+        },
+        {
+            "id": 5,
+            "sample_index": 3,
+            "activation": 0.05,
+            "threshold": 0.53,
+            "decay_rate": 0.88,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "ReLU"
+        },
+        {
+            "id": 6,
+            "sample_index": 4,
+            "activation": 0.03,
+            "threshold": 0.48,
+            "decay_rate": 0.87,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "ReLU"
+        },
+        {
+            "id": 7,
+            "sample_index": 4,
+            "activation": 0.03,
+            "threshold": 0.52,
+            "decay_rate": 0.89,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "ReLU"
+        },
+        {
+            "id": 8,
+            "sample_index": 5,
+            "activation": 0.02,
+            "threshold": 0.60,
+            "decay_rate": 0.90,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 9,
+            "sample_index": 6,
+            "activation": 0.00,
+            "threshold": 0.70,
+            "decay_rate": 0.94,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 10,
+            "sample_index": 7,
+            "activation": 0.00,
+            "threshold": 0.72,
+            "decay_rate": 0.94,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 11,
+            "sample_index": 8,
+            "activation": 0.00,
+            "threshold": 0.76,
+            "decay_rate": 0.96,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 12,
+            "sample_index": 6,
+            "activation": 0.00,
+            "threshold": 0.68,
+            "decay_rate": 0.93,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 13,
+            "sample_index": 7,
+            "activation": 0.00,
+            "threshold": 0.70,
+            "decay_rate": 0.93,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 14,
+            "sample_index": 8,
+            "activation": 0.00,
+            "threshold": 0.78,
+            "decay_rate": 0.96,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 15,
+            "sample_index": 8,
+            "activation": 0.00,
+            "threshold": 0.80,
+            "decay_rate": 0.96,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        }
+    ],
+    "connections": [
+        {
+            "source_id": 0,
+            "target_id": 2,
+            "weight": 0.30
+        },
+        {
+            "source_id": 1,
+            "target_id": 3,
+            "weight": 0.25
+        },
+        {
+            "source_id": 2,
+            "target_id": 4,
+            "weight": 0.25
+        },
+        {
+            "source_id": 4,
+            "target_id": 5,
+            "weight": 0.12
+        },
+        {
+            "source_id": 5,
+            "target_id": 6,
+            "weight": 0.12
+        },
+        {
+            "source_id": 6,
+            "target_id": 11,
+            "weight": 0.15
+        },
+        {
+            "source_id": 7,
+            "target_id": 11,
+            "weight": 0.15
+        },
+        {
+            "source_id": 12,
+            "target_id": 13,
+            "weight": 0.20
+        },
+        {
+            "source_id": 13,
+            "target_id": 14,
+            "weight": 0.20
+        },
+        {
+            "source_id": 14,
+            "target_id": 0,
+            "weight": 0.12
+        },
+        {
+            "source_id": 11,
+            "target_id": 4,
+            "weight": -0.35
+        },
+        {
+            "source_id": 11,
+            "target_id": 5,
+            "weight": -0.35
+        },
+        {
+            "source_id": 11,
+            "target_id": 6,
+            "weight": -0.35
+        },
+        {
+            "source_id": 11,
+            "target_id": 7,
+            "weight": -0.35
+        },
+        {
+            "source_id": 15,
+            "target_id": 4,
+            "weight": -0.30
+        },
+        {
+            "source_id": 15,
+            "target_id": 5,
+            "weight": -0.30
+        },
+        {
+            "source_id": 15,
+            "target_id": 6,
+            "weight": -0.30
+        },
+        {
+            "source_id": 15,
+            "target_id": 7,
+            "weight": -0.30
+        },
+        {
+            "source_id": 9,
+            "target_id": 12,
+            "weight": 0.18
+        },
+        {
+            "source_id": 10,
+            "target_id": 13,
+            "weight": 0.18
+        },
+        {
+            "source_id": 3,
+            "target_id": 8,
+            "weight": 0.20
+        },
+        {
+            "source_id": 8,
+            "target_id": 2,
+            "weight": 0.18
+        },
+        {
+            "source_id": 2,
+            "target_id": 3,
+            "weight": -0.12
+        },
+        {
+            "source_id": 0,
+            "target_id": 1,
+            "weight": -0.12
+        },
+        {
+            "source_id": 4,
+            "target_id": 5,
+            "weight": -0.10
+        },
+        {
+            "source_id": 5,
+            "target_id": 4,
+            "weight": -0.10
+        },
+        {
+            "source_id": 6,
+            "target_id": 7,
+            "weight": 0.10
+        },
+        {
+            "source_id": 7,
+            "target_id": 6,
+            "weight": 0.10
+        },
+        {
+            "source_id": 1,
+            "target_id": 9,
+            "weight": 0.15
+        },
+        {
+            "source_id": 2,
+            "target_id": 10,
+            "weight": 0.15
+        },
+        {
+            "source_id": 12,
+            "target_id": 15,
+            "weight": 0.20
+        },
+        {
+            "source_id": 10,
+            "target_id": 15,
+            "weight": 0.20
+        },
+        {
+            "source_id": 3,
+            "target_id": 6,
+            "weight": 0.10
+        },
+        {
+            "source_id": 5,
+            "target_id": 0,
+            "weight": 0.10
+        },
+        {
+            "source_id": 14,
+            "target_id": 11,
+            "weight": 0.12
+        },
+        {
+            "source_id": 11,
+            "target_id": 0,
+            "weight": 0.10
+        }
+    ],
+    "rhythmogram_matrix": {
+        "enabled": true,
+        "scale": 5.0,
+        "filter_gains": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+        ]
+    },
+    "quantization": {
+        "enabled": true,
+        "grid_resolution": "sixteenth_note",
+        "quantization_amount": 0.65,
+        "swing_factor": 0.58,
+        "bpm": 120.0
+    }
+}

--- a/presets/factory/pjs_pocket.json
+++ b/presets/factory/pjs_pocket.json
@@ -1,0 +1,199 @@
+{
+    "preset_info": {
+        "name": "Basic Pocket (8)",
+        "version": "1.0",
+        "author": "Pekko",
+        "description": "Neuron roles: N0 Kick driver, N1 Kick ghost, N2 Snare backbeat, N3 Snare ghost, N4 CHH tick, N5 OHH breath, N6 Tom motif, N7 Crash accent.",
+        "created_date": "2025-10-30T00:00:00Z",
+        "tags": "drums,basic,groove",
+        "neuron_count": 8,
+        "connection_count": 18
+    },
+    "neurons": [
+        {
+            "id": 0,
+            "sample_index": 1,
+            "activation": 0.20,
+            "threshold": 0.58,
+            "decay_rate": 0.92,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 1,
+            "sample_index": 1,
+            "activation": 0.10,
+            "threshold": 0.64,
+            "decay_rate": 0.93,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 2,
+            "sample_index": 2,
+            "activation": 0.12,
+            "threshold": 0.62,
+            "decay_rate": 0.92,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 3,
+            "sample_index": 2,
+            "activation": 0.06,
+            "threshold": 0.56,
+            "decay_rate": 0.90,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 4,
+            "sample_index": 3,
+            "activation": 0.05,
+            "threshold": 0.50,
+            "decay_rate": 0.88,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "ReLU"
+        },
+        {
+            "id": 5,
+            "sample_index": 4,
+            "activation": 0.03,
+            "threshold": 0.52,
+            "decay_rate": 0.89,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "ReLU"
+        },
+        {
+            "id": 6,
+            "sample_index": 6,
+            "activation": 0.00,
+            "threshold": 0.70,
+            "decay_rate": 0.94,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 7,
+            "sample_index": 8,
+            "activation": 0.00,
+            "threshold": 0.78,
+            "decay_rate": 0.96,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        }
+    ],
+    "connections": [
+        {
+            "source_id": 0,
+            "target_id": 2,
+            "weight": 0.30
+        },
+        {
+            "source_id": 1,
+            "target_id": 3,
+            "weight": 0.25
+        },
+        {
+            "source_id": 2,
+            "target_id": 4,
+            "weight": 0.20
+        },
+        {
+            "source_id": 4,
+            "target_id": 5,
+            "weight": 0.12
+        },
+        {
+            "source_id": 5,
+            "target_id": 7,
+            "weight": 0.10
+        },
+        {
+            "source_id": 6,
+            "target_id": 2,
+            "weight": 0.10
+        },
+        {
+            "source_id": 7,
+            "target_id": 4,
+            "weight": -0.35
+        },
+        {
+            "source_id": 2,
+            "target_id": 4,
+            "weight": -0.20
+        },
+        {
+            "source_id": 2,
+            "target_id": 5,
+            "weight": -0.20
+        },
+        {
+            "source_id": 0,
+            "target_id": 1,
+            "weight": -0.12
+        },
+        {
+            "source_id": 2,
+            "target_id": 3,
+            "weight": -0.12
+        },
+        {
+            "source_id": 4,
+            "target_id": 6,
+            "weight": 0.10
+        },
+        {
+            "source_id": 5,
+            "target_id": 6,
+            "weight": 0.10
+        },
+        {
+            "source_id": 3,
+            "target_id": 4,
+            "weight": 0.10
+        },
+        {
+            "source_id": 1,
+            "target_id": 2,
+            "weight": 0.20
+        },
+        {
+            "source_id": 5,
+            "target_id": 0,
+            "weight": 0.10
+        },
+        {
+            "source_id": 6,
+            "target_id": 0,
+            "weight": 0.10
+        },
+        {
+            "source_id": 7,
+            "target_id": 0,
+            "weight": 0.05
+        }
+    ],
+    "rhythmogram_matrix": {
+        "enabled": true,
+        "scale": 5.0,
+        "filter_gains": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+        ]
+    },
+    "quantization": {
+        "enabled": true,
+        "grid_resolution": "sixteenth_note",
+        "quantization_amount": 0.65,
+        "swing_factor": 0.58,
+        "bpm": 118.0
+    }
+}

--- a/presets/factory/pjs_synco_funk.json
+++ b/presets/factory/pjs_synco_funk.json
@@ -1,0 +1,285 @@
+{
+    "preset_info": {
+        "name": "Syncopated Funk (12)",
+        "version": "1.0",
+        "author": "Pekko",
+        "description": "Neuron roles: N0 Kick driver, N1 Kick off, N2 Snare backbeat, N3 Snare ghost, N4 CHH tick A, N5 CHH tick B, N6 OHH lift, N7 Rim/Clap, N8 Tom low shot, N9 Tom mid shot, N10 Crash tap, N11 Crash choke.",
+        "created_date": "2025-10-30T00:00:00Z",
+        "tags": "drums,funk,syncopation",
+        "neuron_count": 12,
+        "connection_count": 28
+    },
+    "neurons": [
+        {
+            "id": 0,
+            "sample_index": 1,
+            "activation": 0.22,
+            "threshold": 0.58,
+            "decay_rate": 0.92,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 1,
+            "sample_index": 1,
+            "activation": 0.12,
+            "threshold": 0.63,
+            "decay_rate": 0.93,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 2,
+            "sample_index": 2,
+            "activation": 0.10,
+            "threshold": 0.62,
+            "decay_rate": 0.92,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 3,
+            "sample_index": 2,
+            "activation": 0.06,
+            "threshold": 0.56,
+            "decay_rate": 0.90,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 4,
+            "sample_index": 3,
+            "activation": 0.05,
+            "threshold": 0.49,
+            "decay_rate": 0.88,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "ReLU"
+        },
+        {
+            "id": 5,
+            "sample_index": 3,
+            "activation": 0.05,
+            "threshold": 0.51,
+            "decay_rate": 0.88,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "ReLU"
+        },
+        {
+            "id": 6,
+            "sample_index": 4,
+            "activation": 0.03,
+            "threshold": 0.52,
+            "decay_rate": 0.89,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "ReLU"
+        },
+        {
+            "id": 7,
+            "sample_index": 5,
+            "activation": 0.02,
+            "threshold": 0.60,
+            "decay_rate": 0.90,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 8,
+            "sample_index": 6,
+            "activation": 0.00,
+            "threshold": 0.70,
+            "decay_rate": 0.94,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 9,
+            "sample_index": 7,
+            "activation": 0.00,
+            "threshold": 0.72,
+            "decay_rate": 0.94,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 10,
+            "sample_index": 8,
+            "activation": 0.00,
+            "threshold": 0.76,
+            "decay_rate": 0.96,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 11,
+            "sample_index": 8,
+            "activation": 0.00,
+            "threshold": 0.80,
+            "decay_rate": 0.96,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        }
+    ],
+    "connections": [
+        {
+            "source_id": 0,
+            "target_id": 2,
+            "weight": 0.30
+        },
+        {
+            "source_id": 1,
+            "target_id": 3,
+            "weight": 0.25
+        },
+        {
+            "source_id": 2,
+            "target_id": 4,
+            "weight": 0.25
+        },
+        {
+            "source_id": 4,
+            "target_id": 5,
+            "weight": 0.12
+        },
+        {
+            "source_id": 5,
+            "target_id": 6,
+            "weight": 0.12
+        },
+        {
+            "source_id": 7,
+            "target_id": 2,
+            "weight": 0.18
+        },
+        {
+            "source_id": 6,
+            "target_id": 10,
+            "weight": 0.12
+        },
+        {
+            "source_id": 10,
+            "target_id": 4,
+            "weight": -0.35
+        },
+        {
+            "source_id": 10,
+            "target_id": 5,
+            "weight": -0.35
+        },
+        {
+            "source_id": 10,
+            "target_id": 6,
+            "weight": -0.35
+        },
+        {
+            "source_id": 2,
+            "target_id": 4,
+            "weight": -0.22
+        },
+        {
+            "source_id": 2,
+            "target_id": 5,
+            "weight": -0.22
+        },
+        {
+            "source_id": 8,
+            "target_id": 2,
+            "weight": 0.12
+        },
+        {
+            "source_id": 9,
+            "target_id": 1,
+            "weight": 0.12
+        },
+        {
+            "source_id": 0,
+            "target_id": 1,
+            "weight": -0.12
+        },
+        {
+            "source_id": 2,
+            "target_id": 3,
+            "weight": -0.12
+        },
+        {
+            "source_id": 4,
+            "target_id": 5,
+            "weight": -0.10
+        },
+        {
+            "source_id": 5,
+            "target_id": 4,
+            "weight": -0.10
+        },
+        {
+            "source_id": 6,
+            "target_id": 4,
+            "weight": 0.10
+        },
+        {
+            "source_id": 6,
+            "target_id": 5,
+            "weight": 0.10
+        },
+        {
+            "source_id": 3,
+            "target_id": 7,
+            "weight": 0.12
+        },
+        {
+            "source_id": 7,
+            "target_id": 4,
+            "weight": 0.10
+        },
+        {
+            "source_id": 3,
+            "target_id": 6,
+            "weight": 0.10
+        },
+        {
+            "source_id": 11,
+            "target_id": 10,
+            "weight": -0.25
+        },
+        {
+            "source_id": 11,
+            "target_id": 6,
+            "weight": -0.20
+        },
+        {
+            "source_id": 5,
+            "target_id": 0,
+            "weight": 0.10
+        },
+        {
+            "source_id": 8,
+            "target_id": 0,
+            "weight": 0.10
+        },
+        {
+            "source_id": 9,
+            "target_id": 0,
+            "weight": 0.10
+        }
+    ],
+    "rhythmogram_matrix": {
+        "enabled": true,
+        "scale": 5.0,
+        "filter_gains": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+        ]
+    },
+    "quantization": {
+        "enabled": true,
+        "grid_resolution": "sixteenth_note",
+        "quantization_amount": 0.65,
+        "swing_factor": 0.60,
+        "bpm": 112.0
+    }
+}

--- a/src/GUI.cpp
+++ b/src/GUI.cpp
@@ -282,11 +282,16 @@ void GUI::createNeuronSliders() {
     for (auto& combo : activationFunctionCombos) {
         slidersPanel->remove(combo);
     }
+    // Remove sample buttons if any
+    for (auto& btn : neuronSampleButtons) {
+        slidersPanel->remove(btn);
+    }
     
     neuronSliders.clear();
     neuronLabels.clear();
     neuronValueLabels.clear();
     activationFunctionCombos.clear();
+    neuronSampleButtons.clear();
     
     const auto& neurons = network->getNeurons();
     // Always start neuron sliders at a consistent position (not dependent on connection count)
@@ -373,7 +378,44 @@ void GUI::createNeuronSliders() {
         funcLabel->setTextSize(9);
         funcLabel->getRenderer()->setTextColor(tgui::Color::Green);
         slidersPanel->add(funcLabel);
-        
+
+        // Create sample selection button to the right of the function combo
+        std::string sampleFile = neuron->getSampleFilePath();
+        std::string sampleLabelText = "(no sample)";
+        if (!sampleFile.empty()) {
+            try {
+                sampleLabelText = std::filesystem::path(sampleFile).filename().string();
+            } catch (...) {
+                sampleLabelText = "(no sample)";
+            }
+        }
+
+        // Truncate long filenames to avoid UI overlap
+        std::string displayLabel = sampleLabelText;
+        const size_t maxLabelLen = 12;
+        if (displayLabel.size() > maxLabelLen) {
+            displayLabel = displayLabel.substr(0, maxLabelLen - 3) + "...";
+        }
+
+        auto sampleButton = tgui::Button::create(displayLabel);
+        // Position sample button to the right of the function combo but left of connection controls
+        // Func combo is at x=40 width=120 -> ends at 160. Connection column begins at ~215.
+        // Use a small button in the gap (x=165..215)
+        float sampleBtnX = 165.0f;
+        sampleButton->setPosition(sampleBtnX, yPos); // align with function combo row
+        sampleButton->setSize(50, 18);
+        sampleButton->setTextSize(9);
+        sampleButton->getRenderer()->setBackgroundColor(tgui::Color(70, 70, 70));
+        sampleButton->getRenderer()->setTextColor(tgui::Color::White);
+
+        // Capture index for the callback
+        sampleButton->onPress([this, i]() {
+            this->showChangeSampleDialog(i);
+        });
+
+        slidersPanel->add(sampleButton);
+        neuronSampleButtons.push_back(sampleButton);
+
         yPos += 22.0f; // Extra spacing after each neuron's controls
     }
     
@@ -1138,6 +1180,163 @@ void GUI::showAddNeuronDialog() {
     });
     dialog->add(cancelButton);
     
+    gui->add(dialog);
+}
+
+void GUI::showChangeSampleDialog(size_t neuronIndex) {
+    if (!network) return;
+
+    if (neuronIndex >= network->getNeuronCount()) return;
+
+    Neuron* neuron = network->getNeuron(neuronIndex);
+    if (!neuron) return;
+
+    // Create dialog window for changing sample
+    auto dialog = tgui::ChildWindow::create("Change Neuron Sample");
+    dialog->setSize(420, 360);
+    dialog->setPosition("50% - 210", "50% - 180");
+    dialog->getRenderer()->setTitleBarHeight(30);
+    dialog->getRenderer()->setBackgroundColor(tgui::Color(40, 40, 40, 240));
+
+    auto dirLabel = tgui::Label::create("Sample Directory:");
+    dirLabel->setPosition(10, 40);
+    dirLabel->setSize(150, 25);
+    dirLabel->getRenderer()->setTextColor(tgui::Color::White);
+    dialog->add(dirLabel);
+
+    auto dirComboBox = tgui::ComboBox::create();
+    dirComboBox->setPosition(10, 70);
+    dirComboBox->setSize(200, 25);
+    dialog->add(dirComboBox, "dirComboBox");
+
+    auto fileLabel = tgui::Label::create("Sample File:");
+    fileLabel->setPosition(10, 110);
+    fileLabel->setSize(150, 25);
+    dialog->add(fileLabel);
+
+    auto fileListBox = tgui::ListBox::create();
+    fileListBox->setPosition(10, 140);
+    fileListBox->setSize(400, 160);
+    dialog->add(fileListBox, "fileListBox");
+
+    // Populate directories
+    auto sampleDirs = getAllSampleDirectories();
+    for (const auto& d : sampleDirs) dirComboBox->addItem(d);
+    if (!sampleDirs.empty()) dirComboBox->setSelectedItem(sampleDirs[0]);
+
+    // Update file list when directory changes
+    dirComboBox->onItemSelect([=]() {
+        auto selectedDir = dirComboBox->getSelectedItem();
+        if (!selectedDir.empty()) {
+            fileListBox->removeAllItems();
+            auto files = getSampleFiles("samples/" + selectedDir.toStdString());
+            for (const auto& file : files) fileListBox->addItem(file);
+        }
+    });
+
+    // Initialize file list with first directory
+    if (!sampleDirs.empty()) {
+        auto files = getSampleFiles("samples/" + sampleDirs[0]);
+        for (const auto& file : files) fileListBox->addItem(file);
+    }
+
+    // Pre-select current file if known
+    std::string curPath = neuron->getSampleFilePath();
+    if (!curPath.empty()) {
+        try {
+            auto p = std::filesystem::path(curPath);
+            auto parent = p.parent_path().filename().string();
+            auto fname = p.filename().string();
+            if (!parent.empty()) {
+                dirComboBox->setSelectedItem(parent);
+                fileListBox->removeAllItems();
+                auto files = getSampleFiles("samples/" + parent);
+                for (const auto& file : files) fileListBox->addItem(file);
+                // Try to pre-select matching file in the list if available.
+                // TGUI ListBox selection API varies between versions; leave unselected if method not present.
+                (void)fname; // silence unused variable warning when selection is skipped
+            }
+        } catch (...) {
+            // ignore
+        }
+    }
+
+    // Buttons
+    auto changeButton = tgui::Button::create("Change Sample");
+    changeButton->setPosition(10, 310);
+    changeButton->setSize(140, 30);
+    changeButton->onPress([=]() {
+        auto selectedDir = dirComboBox->getSelectedItem();
+        auto selectedFile = fileListBox->getSelectedItem();
+
+        if (selectedDir.empty() || selectedFile.empty()) return;
+
+        std::string fullPath = "samples/" + selectedDir.toStdString() + "/" + selectedFile.toStdString();
+
+        if (!audioManager) {
+            std::cerr << "No AudioManager available to load sample" << std::endl;
+            dialog->close();
+            return;
+        }
+
+        int assignedIndex = neuron->getSampleIndex();
+        if (assignedIndex <= 0) {
+            // Provide a default mapping if neuron doesn't have an index
+            assignedIndex = static_cast<int>(neuronIndex) + 1;
+            neuron->setSampleIndex(assignedIndex);
+        }
+
+        if (!audioManager->loadSampleFromPath(assignedIndex, fullPath)) {
+            std::cerr << "Failed to load sample: " << fullPath << std::endl;
+            // Show small error dialog
+            auto err = tgui::ChildWindow::create("Error");
+            err->setSize(300, 120);
+            err->setPosition("50% - 150", "50% - 60");
+            auto msg = tgui::Label::create("Failed to load sample file: " + selectedFile.toStdString());
+            msg->setPosition(10, 20);
+            msg->setSize(280, 60);
+            err->add(msg);
+            auto ok = tgui::Button::create("OK");
+            ok->setPosition(100, 70);
+            ok->setSize(100, 30);
+            ok->onPress([err]() { err->close(); });
+            err->add(ok);
+            gui->add(err);
+            return;
+        }
+
+        // Update neuron's sample file path
+        neuron->setSampleFilePath(fullPath);
+
+        // Update sample button text to show filename
+        if (neuronIndex < neuronSampleButtons.size()) {
+            try {
+                std::string label = std::filesystem::path(fullPath).filename().string();
+                // Truncate long filenames to fit the small button
+                const size_t maxLabelLen = 12;
+                std::string display = label;
+                if (display.size() > maxLabelLen) display = display.substr(0, maxLabelLen - 3) + "...";
+                neuronSampleButtons[neuronIndex]->setText(display);
+            } catch (...) {
+                std::string display = selectedFile.toStdString();
+                const size_t maxLabelLen = 12;
+                if (display.size() > maxLabelLen) display = display.substr(0, maxLabelLen - 3) + "...";
+                neuronSampleButtons[neuronIndex]->setText(display);
+            }
+        }
+
+        std::cout << "Neuron " << neuronIndex << " sample changed to " << fullPath << std::endl;
+
+        dialog->close();
+    });
+    dialog->add(changeButton);
+
+    auto cancelButton = tgui::Button::create("Cancel");
+    cancelButton->setPosition(160, 310);
+    cancelButton->setSize(100, 30);
+    cancelButton->onPress([=]() { dialog->close(); });
+    dialog->add(cancelButton);
+
     gui->add(dialog);
 }
 

--- a/src/GUI.h
+++ b/src/GUI.h
@@ -50,6 +50,7 @@ private:
     std::vector<tgui::Label::Ptr> neuronLabels;
     std::vector<tgui::Label::Ptr> neuronValueLabels;
     std::vector<tgui::ComboBox::Ptr> activationFunctionCombos;
+    std::vector<tgui::Button::Ptr> neuronSampleButtons; // Button to change/select sample for each neuron
     tgui::Slider::Ptr activationIntervalSlider;
     tgui::Label::Ptr activationIntervalLabel;
     tgui::ComboBox::Ptr viewModeComboBox;
@@ -159,6 +160,7 @@ private:
     void onSliderChanged(size_t connectionIndex, float value);
     void onNeuronSliderChanged(size_t neuronIndex, float value);
     void onActivationFunctionChanged(size_t neuronIndex, const std::string& functionName);
+    void showChangeSampleDialog(size_t neuronIndex);
 
 public:
     GUI(tgui::Gui* tguiGui, sf::RenderWindow* renderWindow, NeuronNetwork* neuronNetwork, 


### PR DESCRIPTION
This pull request adds four new neural drum preset JSON files to the `presets/factory` directory. Each preset defines a different drum brain configuration, varying in neuron count, sample slot usage, and network connectivity, to support generative, groove, and fill-oriented drum patterns.

**New neural drum preset additions:**

* Added `pjs_drum_brain-v1.json`: A 16-neuron drum brain featuring kick, snare, hat, and FX roles, with groove links and light inhibition for generative drum patterns.
* Added `pjs_drum_brain_basic.json`: A 16-neuron network using only basic drum kit sample slots (1–8), with multiple neurons per slot to enable groove variation.
* Added `pjs_drum_brain_4.json`: A compact 4-neuron drum brain preset using sample slots 1–4, suitable for simple kick, snare, hat, and FX patterns.
* Added `pjs_fill_machine.json`: A 16-neuron fill machine preset, with specialized neuron roles for fills, tom chains, cymbal throws, and brake/mute behaviors to enhance drum performance dynamics.