### PR TITLE
UI tinkering

### DIFF
--- a/presets/factory/pjs_drum_brain-v1.json
+++ b/presets/factory/pjs_drum_brain-v1.json
@@ -1,0 +1,82 @@
+{
+    "preset_info": {
+        "name": "Drum Brain v1",
+            "version": "1.0",
+                "author": "Pekko",
+                    "description": "16-neuron kick/snare/hat/fx brain with light inhibition and groove links",
+                        "created_date": "2025-10-30T00:00:00Z",
+                            "tags": "drums,generative,neural",
+                                "neuron_count": 16,
+                                    "connection_count": 29
+    },
+    "neurons": [
+        { "id": 0, "sample_index": 1, "activation": 0.0, "threshold": 0.58, "decay_rate": 0.92, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 1, "sample_index": 2, "activation": 0.0, "threshold": 0.60, "decay_rate": 0.93, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 2, "sample_index": 3, "activation": 0.0, "threshold": 0.63, "decay_rate": 0.93, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 3, "sample_index": 4, "activation": 0.0, "threshold": 0.62, "decay_rate": 0.94, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+
+        { "id": 4, "sample_index": 5, "activation": 0.0, "threshold": 0.64, "decay_rate": 0.92, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 5, "sample_index": 6, "activation": 0.0, "threshold": 0.66, "decay_rate": 0.92, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 6, "sample_index": 7, "activation": 0.0, "threshold": 0.56, "decay_rate": 0.90, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 7, "sample_index": 8, "activation": 0.0, "threshold": 0.70, "decay_rate": 0.93, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+
+        { "id": 8, "sample_index": 9, "activation": 0.0, "threshold": 0.50, "decay_rate": 0.88, "activation_increase_per_iteration": 0.0, "activation_function": "ReLU" },
+        { "id": 9, "sample_index": 10, "activation": 0.0, "threshold": 0.52, "decay_rate": 0.88, "activation_increase_per_iteration": 0.0, "activation_function": "ReLU" },
+        { "id": 10, "sample_index": 11, "activation": 0.0, "threshold": 0.48, "decay_rate": 0.87, "activation_increase_per_iteration": 0.0, "activation_function": "ReLU" },
+        { "id": 11, "sample_index": 12, "activation": 0.0, "threshold": 0.53, "decay_rate": 0.89, "activation_increase_per_iteration": 0.0, "activation_function": "ReLU" },
+
+        { "id": 12, "sample_index": 13, "activation": 0.0, "threshold": 0.72, "decay_rate": 0.95, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 13, "sample_index": 14, "activation": 0.0, "threshold": 0.70, "decay_rate": 0.95, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 14, "sample_index": 15, "activation": 0.0, "threshold": 0.74, "decay_rate": 0.96, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 15, "sample_index": 16, "activation": 0.0, "threshold": 0.76, "decay_rate": 0.96, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" }
+    ],
+        "connections": [
+            { "source_id": 1, "target_id": 5, "weight": 0.35 },
+            { "source_id": 5, "target_id": 6, "weight": 0.25 },
+            { "source_id": 5, "target_id": 7, "weight": -0.20 },
+
+            { "source_id": 8, "target_id": 9, "weight": 0.15 },
+            { "source_id": 9, "target_id": 8, "weight": 0.15 },
+            { "source_id": 10, "target_id": 11, "weight": 0.15 },
+            { "source_id": 11, "target_id": 10, "weight": 0.15 },
+
+            { "source_id": 5, "target_id": 8, "weight": -0.25 },
+            { "source_id": 5, "target_id": 9, "weight": -0.25 },
+            { "source_id": 5, "target_id": 10, "weight": -0.25 },
+            { "source_id": 5, "target_id": 11, "weight": -0.25 },
+
+            { "source_id": 3, "target_id": 12, "weight": 0.25 },
+            { "source_id": 7, "target_id": 13, "weight": 0.25 },
+            { "source_id": 11, "target_id": 14, "weight": 0.15 },
+
+            { "source_id": 15, "target_id": 8, "weight": -0.35 },
+            { "source_id": 15, "target_id": 9, "weight": -0.35 },
+            { "source_id": 15, "target_id": 10, "weight": -0.35 },
+            { "source_id": 15, "target_id": 11, "weight": -0.35 },
+
+            { "source_id": 0, "target_id": 1, "weight": -0.10 },
+            { "source_id": 1, "target_id": 2, "weight": -0.10 },
+            { "source_id": 2, "target_id": 3, "weight": -0.10 },
+            { "source_id": 4, "target_id": 5, "weight": -0.10 },
+            { "source_id": 6, "target_id": 7, "weight": -0.10 },
+            { "source_id": 8, "target_id": 10, "weight": -0.10 },
+            { "source_id": 9, "target_id": 11, "weight": -0.10 },
+
+            { "source_id": 0, "target_id": 4, "weight": 0.20 },
+            { "source_id": 2, "target_id": 6, "weight": 0.15 },
+            { "source_id": 12, "target_id": 15, "weight": 0.10 },
+            { "source_id": 5, "target_id": 12, "weight": 0.10 }
+        ],
+            "rhythmogram_matrix": {
+        "enabled": true,
+            "scale": 5.0,
+                "filter_gains": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+    },
+    "quantization": {
+        "enabled": true,
+            "grid_resolution": "sixteenth_note",
+                "quantization_amount": 0.65,
+                    "swing_factor": 0.58,
+                        "bpm": 120.0
+    }
+}

--- a/presets/factory/pjs_drum_brain_4.json
+++ b/presets/factory/pjs_drum_brain_4.json
@@ -1,0 +1,103 @@
+{
+    "preset_info": {
+        "name": "Drum Brain v1 (4-sample)",
+        "version": "1.0",
+        "author": "Pekko",
+        "description": "Compact 4-neuron drum brain using sample slots 1–4 (kick, snare, hat, fx)",
+        "created_date": "2025-10-30T00:00:00Z",
+        "tags": "drums,neural,compact",
+        "neuron_count": 4,
+        "connection_count": 6
+    },
+    "neurons": [
+        {
+            "id": 0,
+            "sample_index": 1,
+            "activation": 0.0,
+            "threshold": 0.58,
+            "decay_rate": 0.92,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 1,
+            "sample_index": 2,
+            "activation": 0.0,
+            "threshold": 0.64,
+            "decay_rate": 0.90,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 2,
+            "sample_index": 3,
+            "activation": 0.0,
+            "threshold": 0.52,
+            "decay_rate": 0.88,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "ReLU"
+        },
+        {
+            "id": 3,
+            "sample_index": 4,
+            "activation": 0.0,
+            "threshold": 0.70,
+            "decay_rate": 0.94,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        }
+    ],
+    "connections": [
+        {
+            "source_id": 0,
+            "target_id": 1,
+            "weight": 0.5
+        },
+        {
+            "source_id": 1,
+            "target_id": 2,
+            "weight": 0.4
+        },
+        {
+            "source_id": 2,
+            "target_id": 3,
+            "weight": 0.3
+        },
+        {
+            "source_id": 3,
+            "target_id": 0,
+            "weight": 0.2
+        },
+        {
+            "source_id": 1,
+            "target_id": 0,
+            "weight": -0.2
+        },
+        {
+            "source_id": 2,
+            "target_id": 1,
+            "weight": -0.2
+        }
+    ],
+    "rhythmogram_matrix": {
+        "enabled": true,
+        "scale": 5.0,
+        "filter_gains": [
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0
+        ]
+    },
+    "quantization": {
+        "enabled": true,
+        "grid_resolution": "sixteenth_note",
+        "quantization_amount": 0.7,
+        "swing_factor": 0.55,
+        "bpm": 120.0
+    }
+}

--- a/presets/factory/pjs_drum_brain_basic.json
+++ b/presets/factory/pjs_drum_brain_basic.json
@@ -1,0 +1,89 @@
+{
+    "preset_info": {
+        "name": "Drum Brain v1 (Basic Kit)",
+            "version": "1.0",
+                "author": "Pekko",
+                    "description": "16-neuron network using only basic drum kit slots (1–8). Multiple neurons per slot for groove variation.",
+                        "created_date": "2025-10-30T00:00:00Z",
+                            "tags": "drums,neural,basic-kit",
+                                "neuron_count": 16,
+                                    "connection_count": 33
+    },
+    "neurons": [
+        { "id": 0, "sample_index": 1, "activation": 0.22, "threshold": 0.58, "decay_rate": 0.92, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 1, "sample_index": 1, "activation": 0.18, "threshold": 0.62, "decay_rate": 0.93, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 2, "sample_index": 2, "activation": 0.12, "threshold": 0.64, "decay_rate": 0.92, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 3, "sample_index": 2, "activation": 0.08, "threshold": 0.66, "decay_rate": 0.92, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+
+        { "id": 4, "sample_index": 3, "activation": 0.04, "threshold": 0.50, "decay_rate": 0.88, "activation_increase_per_iteration": 0.0, "activation_function": "ReLU" },
+        { "id": 5, "sample_index": 3, "activation": 0.04, "threshold": 0.53, "decay_rate": 0.88, "activation_increase_per_iteration": 0.0, "activation_function": "ReLU" },
+        { "id": 6, "sample_index": 4, "activation": 0.02, "threshold": 0.48, "decay_rate": 0.87, "activation_increase_per_iteration": 0.0, "activation_function": "ReLU" },
+        { "id": 7, "sample_index": 4, "activation": 0.02, "threshold": 0.52, "decay_rate": 0.89, "activation_increase_per_iteration": 0.0, "activation_function": "ReLU" },
+
+        { "id": 8, "sample_index": 5, "activation": 0.00, "threshold": 0.60, "decay_rate": 0.90, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 9, "sample_index": 6, "activation": 0.00, "threshold": 0.70, "decay_rate": 0.94, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 10, "sample_index": 7, "activation": 0.00, "threshold": 0.72, "decay_rate": 0.94, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 11, "sample_index": 8, "activation": 0.00, "threshold": 0.76, "decay_rate": 0.96, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+
+        { "id": 12, "sample_index": 2, "activation": 0.05, "threshold": 0.56, "decay_rate": 0.90, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 13, "sample_index": 3, "activation": 0.03, "threshold": 0.47, "decay_rate": 0.86, "activation_increase_per_iteration": 0.0, "activation_function": "ReLU" },
+        { "id": 14, "sample_index": 1, "activation": 0.10, "threshold": 0.63, "decay_rate": 0.93, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" },
+        { "id": 15, "sample_index": 8, "activation": 0.00, "threshold": 0.78, "decay_rate": 0.96, "activation_increase_per_iteration": 0.0, "activation_function": "Tanh" }
+    ],
+        "connections": [
+            { "source_id": 0, "target_id": 2, "weight": 0.30 },
+            { "source_id": 1, "target_id": 3, "weight": 0.35 },
+            { "source_id": 14, "target_id": 2, "weight": 0.25 },
+
+            { "source_id": 2, "target_id": 12, "weight": 0.25 },
+            { "source_id": 3, "target_id": 8, "weight": 0.20 },
+
+            { "source_id": 2, "target_id": 4, "weight": -0.25 },
+            { "source_id": 2, "target_id": 5, "weight": -0.25 },
+            { "source_id": 2, "target_id": 6, "weight": -0.20 },
+            { "source_id": 2, "target_id": 7, "weight": -0.20 },
+            { "source_id": 3, "target_id": 4, "weight": -0.20 },
+
+            { "source_id": 4, "target_id": 5, "weight": 0.12 },
+            { "source_id": 5, "target_id": 4, "weight": 0.12 },
+            { "source_id": 6, "target_id": 7, "weight": 0.12 },
+            { "source_id": 7, "target_id": 6, "weight": 0.12 },
+            { "source_id": 4, "target_id": 6, "weight": 0.10 },
+            { "source_id": 5, "target_id": 7, "weight": 0.10 },
+
+            { "source_id": 7, "target_id": 11, "weight": 0.15 },
+            { "source_id": 3, "target_id": 9, "weight": 0.25 },
+            { "source_id": 6, "target_id": 10, "weight": 0.20 },
+
+            { "source_id": 11, "target_id": 4, "weight": -0.35 },
+            { "source_id": 11, "target_id": 5, "weight": -0.35 },
+            { "source_id": 11, "target_id": 6, "weight": -0.35 },
+            { "source_id": 11, "target_id": 7, "weight": -0.35 },
+
+            { "source_id": 9, "target_id": 0, "weight": 0.10 },
+            { "source_id": 10, "target_id": 1, "weight": 0.10 },
+
+            { "source_id": 0, "target_id": 1, "weight": -0.10 },
+            { "source_id": 1, "target_id": 14, "weight": -0.10 },
+            { "source_id": 2, "target_id": 3, "weight": -0.10 },
+            { "source_id": 4, "target_id": 5, "weight": -0.10 },
+            { "source_id": 6, "target_id": 7, "weight": -0.10 },
+
+            { "source_id": 0, "target_id": 13, "weight": 0.15 },
+            { "source_id": 13, "target_id": 4, "weight": 0.10 },
+            { "source_id": 10, "target_id": 15, "weight": 0.20 },
+            { "source_id": 15, "target_id": 8, "weight": -0.20 }
+        ],
+            "rhythmogram_matrix": {
+        "enabled": true,
+            "scale": 5.0,
+                "filter_gains": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+    },
+    "quantization": {
+        "enabled": true,
+            "grid_resolution": "sixteenth_note",
+                "quantization_amount": 0.65,
+                    "swing_factor": 0.58,
+                        "bpm": 120.0
+    }
+}

--- a/presets/factory/pjs_fill_machine.json
+++ b/presets/factory/pjs_fill_machine.json
@@ -1,0 +1,361 @@
+{
+    "preset_info": {
+        "name": "Fill Machine (16)",
+        "version": "1.0",
+        "author": "Pekko",
+        "description": "Neuron roles: N0 Kick driver, N1 Kick alt, N2 Snare backbeat, N3 Snare ghost, N4 CHH A, N5 CHH B, N6 OHH breath, N7 OHH wash, N8 Rim/Clap, N9 Tom low, N10 Tom mid, N11 Crash tap, N12 Fill tom chain A, N13 Fill tom chain B, N14 Cym throw, N15 Brake (mutes hats before fills).",
+        "created_date": "2025-10-30T00:00:00Z",
+        "tags": "drums,fills,performance",
+        "neuron_count": 16,
+        "connection_count": 36
+    },
+    "neurons": [
+        {
+            "id": 0,
+            "sample_index": 1,
+            "activation": 0.22,
+            "threshold": 0.58,
+            "decay_rate": 0.92,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 1,
+            "sample_index": 1,
+            "activation": 0.14,
+            "threshold": 0.63,
+            "decay_rate": 0.93,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 2,
+            "sample_index": 2,
+            "activation": 0.12,
+            "threshold": 0.62,
+            "decay_rate": 0.92,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 3,
+            "sample_index": 2,
+            "activation": 0.06,
+            "threshold": 0.56,
+            "decay_rate": 0.90,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 4,
+            "sample_index": 3,
+            "activation": 0.05,
+            "threshold": 0.50,
+            "decay_rate": 0.88,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "ReLU"
+        },
+        {
+            "id": 5,
+            "sample_index": 3,
+            "activation": 0.05,
+            "threshold": 0.53,
+            "decay_rate": 0.88,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "ReLU"
+        },
+        {
+            "id": 6,
+            "sample_index": 4,
+            "activation": 0.03,
+            "threshold": 0.48,
+            "decay_rate": 0.87,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "ReLU"
+        },
+        {
+            "id": 7,
+            "sample_index": 4,
+            "activation": 0.03,
+            "threshold": 0.52,
+            "decay_rate": 0.89,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "ReLU"
+        },
+        {
+            "id": 8,
+            "sample_index": 5,
+            "activation": 0.02,
+            "threshold": 0.60,
+            "decay_rate": 0.90,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 9,
+            "sample_index": 6,
+            "activation": 0.00,
+            "threshold": 0.70,
+            "decay_rate": 0.94,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 10,
+            "sample_index": 7,
+            "activation": 0.00,
+            "threshold": 0.72,
+            "decay_rate": 0.94,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 11,
+            "sample_index": 8,
+            "activation": 0.00,
+            "threshold": 0.76,
+            "decay_rate": 0.96,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 12,
+            "sample_index": 6,
+            "activation": 0.00,
+            "threshold": 0.68,
+            "decay_rate": 0.93,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 13,
+            "sample_index": 7,
+            "activation": 0.00,
+            "threshold": 0.70,
+            "decay_rate": 0.93,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 14,
+            "sample_index": 8,
+            "activation": 0.00,
+            "threshold": 0.78,
+            "decay_rate": 0.96,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 15,
+            "sample_index": 8,
+            "activation": 0.00,
+            "threshold": 0.80,
+            "decay_rate": 0.96,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        }
+    ],
+    "connections": [
+        {
+            "source_id": 0,
+            "target_id": 2,
+            "weight": 0.30
+        },
+        {
+            "source_id": 1,
+            "target_id": 3,
+            "weight": 0.25
+        },
+        {
+            "source_id": 2,
+            "target_id": 4,
+            "weight": 0.25
+        },
+        {
+            "source_id": 4,
+            "target_id": 5,
+            "weight": 0.12
+        },
+        {
+            "source_id": 5,
+            "target_id": 6,
+            "weight": 0.12
+        },
+        {
+            "source_id": 6,
+            "target_id": 11,
+            "weight": 0.15
+        },
+        {
+            "source_id": 7,
+            "target_id": 11,
+            "weight": 0.15
+        },
+        {
+            "source_id": 12,
+            "target_id": 13,
+            "weight": 0.20
+        },
+        {
+            "source_id": 13,
+            "target_id": 14,
+            "weight": 0.20
+        },
+        {
+            "source_id": 14,
+            "target_id": 0,
+            "weight": 0.12
+        },
+        {
+            "source_id": 11,
+            "target_id": 4,
+            "weight": -0.35
+        },
+        {
+            "source_id": 11,
+            "target_id": 5,
+            "weight": -0.35
+        },
+        {
+            "source_id": 11,
+            "target_id": 6,
+            "weight": -0.35
+        },
+        {
+            "source_id": 11,
+            "target_id": 7,
+            "weight": -0.35
+        },
+        {
+            "source_id": 15,
+            "target_id": 4,
+            "weight": -0.30
+        },
+        {
+            "source_id": 15,
+            "target_id": 5,
+            "weight": -0.30
+        },
+        {
+            "source_id": 15,
+            "target_id": 6,
+            "weight": -0.30
+        },
+        {
+            "source_id": 15,
+            "target_id": 7,
+            "weight": -0.30
+        },
+        {
+            "source_id": 9,
+            "target_id": 12,
+            "weight": 0.18
+        },
+        {
+            "source_id": 10,
+            "target_id": 13,
+            "weight": 0.18
+        },
+        {
+            "source_id": 3,
+            "target_id": 8,
+            "weight": 0.20
+        },
+        {
+            "source_id": 8,
+            "target_id": 2,
+            "weight": 0.18
+        },
+        {
+            "source_id": 2,
+            "target_id": 3,
+            "weight": -0.12
+        },
+        {
+            "source_id": 0,
+            "target_id": 1,
+            "weight": -0.12
+        },
+        {
+            "source_id": 4,
+            "target_id": 5,
+            "weight": -0.10
+        },
+        {
+            "source_id": 5,
+            "target_id": 4,
+            "weight": -0.10
+        },
+        {
+            "source_id": 6,
+            "target_id": 7,
+            "weight": 0.10
+        },
+        {
+            "source_id": 7,
+            "target_id": 6,
+            "weight": 0.10
+        },
+        {
+            "source_id": 1,
+            "target_id": 9,
+            "weight": 0.15
+        },
+        {
+            "source_id": 2,
+            "target_id": 10,
+            "weight": 0.15
+        },
+        {
+            "source_id": 12,
+            "target_id": 15,
+            "weight": 0.20
+        },
+        {
+            "source_id": 10,
+            "target_id": 15,
+            "weight": 0.20
+        },
+        {
+            "source_id": 3,
+            "target_id": 6,
+            "weight": 0.10
+        },
+        {
+            "source_id": 5,
+            "target_id": 0,
+            "weight": 0.10
+        },
+        {
+            "source_id": 14,
+            "target_id": 11,
+            "weight": 0.12
+        },
+        {
+            "source_id": 11,
+            "target_id": 0,
+            "weight": 0.10
+        }
+    ],
+    "rhythmogram_matrix": {
+        "enabled": true,
+        "scale": 5.0,
+        "filter_gains": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+        ]
+    },
+    "quantization": {
+        "enabled": true,
+        "grid_resolution": "sixteenth_note",
+        "quantization_amount": 0.65,
+        "swing_factor": 0.58,
+        "bpm": 120.0
+    }
+}

--- a/presets/factory/pjs_pocket.json
+++ b/presets/factory/pjs_pocket.json
@@ -1,0 +1,199 @@
+{
+    "preset_info": {
+        "name": "Basic Pocket (8)",
+        "version": "1.0",
+        "author": "Pekko",
+        "description": "Neuron roles: N0 Kick driver, N1 Kick ghost, N2 Snare backbeat, N3 Snare ghost, N4 CHH tick, N5 OHH breath, N6 Tom motif, N7 Crash accent.",
+        "created_date": "2025-10-30T00:00:00Z",
+        "tags": "drums,basic,groove",
+        "neuron_count": 8,
+        "connection_count": 18
+    },
+    "neurons": [
+        {
+            "id": 0,
+            "sample_index": 1,
+            "activation": 0.20,
+            "threshold": 0.58,
+            "decay_rate": 0.92,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 1,
+            "sample_index": 1,
+            "activation": 0.10,
+            "threshold": 0.64,
+            "decay_rate": 0.93,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 2,
+            "sample_index": 2,
+            "activation": 0.12,
+            "threshold": 0.62,
+            "decay_rate": 0.92,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 3,
+            "sample_index": 2,
+            "activation": 0.06,
+            "threshold": 0.56,
+            "decay_rate": 0.90,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 4,
+            "sample_index": 3,
+            "activation": 0.05,
+            "threshold": 0.50,
+            "decay_rate": 0.88,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "ReLU"
+        },
+        {
+            "id": 5,
+            "sample_index": 4,
+            "activation": 0.03,
+            "threshold": 0.52,
+            "decay_rate": 0.89,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "ReLU"
+        },
+        {
+            "id": 6,
+            "sample_index": 6,
+            "activation": 0.00,
+            "threshold": 0.70,
+            "decay_rate": 0.94,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 7,
+            "sample_index": 8,
+            "activation": 0.00,
+            "threshold": 0.78,
+            "decay_rate": 0.96,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        }
+    ],
+    "connections": [
+        {
+            "source_id": 0,
+            "target_id": 2,
+            "weight": 0.30
+        },
+        {
+            "source_id": 1,
+            "target_id": 3,
+            "weight": 0.25
+        },
+        {
+            "source_id": 2,
+            "target_id": 4,
+            "weight": 0.20
+        },
+        {
+            "source_id": 4,
+            "target_id": 5,
+            "weight": 0.12
+        },
+        {
+            "source_id": 5,
+            "target_id": 7,
+            "weight": 0.10
+        },
+        {
+            "source_id": 6,
+            "target_id": 2,
+            "weight": 0.10
+        },
+        {
+            "source_id": 7,
+            "target_id": 4,
+            "weight": -0.35
+        },
+        {
+            "source_id": 2,
+            "target_id": 4,
+            "weight": -0.20
+        },
+        {
+            "source_id": 2,
+            "target_id": 5,
+            "weight": -0.20
+        },
+        {
+            "source_id": 0,
+            "target_id": 1,
+            "weight": -0.12
+        },
+        {
+            "source_id": 2,
+            "target_id": 3,
+            "weight": -0.12
+        },
+        {
+            "source_id": 4,
+            "target_id": 6,
+            "weight": 0.10
+        },
+        {
+            "source_id": 5,
+            "target_id": 6,
+            "weight": 0.10
+        },
+        {
+            "source_id": 3,
+            "target_id": 4,
+            "weight": 0.10
+        },
+        {
+            "source_id": 1,
+            "target_id": 2,
+            "weight": 0.20
+        },
+        {
+            "source_id": 5,
+            "target_id": 0,
+            "weight": 0.10
+        },
+        {
+            "source_id": 6,
+            "target_id": 0,
+            "weight": 0.10
+        },
+        {
+            "source_id": 7,
+            "target_id": 0,
+            "weight": 0.05
+        }
+    ],
+    "rhythmogram_matrix": {
+        "enabled": true,
+        "scale": 5.0,
+        "filter_gains": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+        ]
+    },
+    "quantization": {
+        "enabled": true,
+        "grid_resolution": "sixteenth_note",
+        "quantization_amount": 0.65,
+        "swing_factor": 0.58,
+        "bpm": 118.0
+    }
+}

--- a/presets/factory/pjs_synco_funk.json
+++ b/presets/factory/pjs_synco_funk.json
@@ -1,0 +1,285 @@
+{
+    "preset_info": {
+        "name": "Syncopated Funk (12)",
+        "version": "1.0",
+        "author": "Pekko",
+        "description": "Neuron roles: N0 Kick driver, N1 Kick off, N2 Snare backbeat, N3 Snare ghost, N4 CHH tick A, N5 CHH tick B, N6 OHH lift, N7 Rim/Clap, N8 Tom low shot, N9 Tom mid shot, N10 Crash tap, N11 Crash choke.",
+        "created_date": "2025-10-30T00:00:00Z",
+        "tags": "drums,funk,syncopation",
+        "neuron_count": 12,
+        "connection_count": 28
+    },
+    "neurons": [
+        {
+            "id": 0,
+            "sample_index": 1,
+            "activation": 0.22,
+            "threshold": 0.58,
+            "decay_rate": 0.92,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 1,
+            "sample_index": 1,
+            "activation": 0.12,
+            "threshold": 0.63,
+            "decay_rate": 0.93,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 2,
+            "sample_index": 2,
+            "activation": 0.10,
+            "threshold": 0.62,
+            "decay_rate": 0.92,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 3,
+            "sample_index": 2,
+            "activation": 0.06,
+            "threshold": 0.56,
+            "decay_rate": 0.90,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 4,
+            "sample_index": 3,
+            "activation": 0.05,
+            "threshold": 0.49,
+            "decay_rate": 0.88,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "ReLU"
+        },
+        {
+            "id": 5,
+            "sample_index": 3,
+            "activation": 0.05,
+            "threshold": 0.51,
+            "decay_rate": 0.88,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "ReLU"
+        },
+        {
+            "id": 6,
+            "sample_index": 4,
+            "activation": 0.03,
+            "threshold": 0.52,
+            "decay_rate": 0.89,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "ReLU"
+        },
+        {
+            "id": 7,
+            "sample_index": 5,
+            "activation": 0.02,
+            "threshold": 0.60,
+            "decay_rate": 0.90,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 8,
+            "sample_index": 6,
+            "activation": 0.00,
+            "threshold": 0.70,
+            "decay_rate": 0.94,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 9,
+            "sample_index": 7,
+            "activation": 0.00,
+            "threshold": 0.72,
+            "decay_rate": 0.94,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 10,
+            "sample_index": 8,
+            "activation": 0.00,
+            "threshold": 0.76,
+            "decay_rate": 0.96,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        },
+        {
+            "id": 11,
+            "sample_index": 8,
+            "activation": 0.00,
+            "threshold": 0.80,
+            "decay_rate": 0.96,
+            "activation_increase_per_iteration": 0.0,
+            "activation_function": "Tanh"
+        }
+    ],
+    "connections": [
+        {
+            "source_id": 0,
+            "target_id": 2,
+            "weight": 0.30
+        },
+        {
+            "source_id": 1,
+            "target_id": 3,
+            "weight": 0.25
+        },
+        {
+            "source_id": 2,
+            "target_id": 4,
+            "weight": 0.25
+        },
+        {
+            "source_id": 4,
+            "target_id": 5,
+            "weight": 0.12
+        },
+        {
+            "source_id": 5,
+            "target_id": 6,
+            "weight": 0.12
+        },
+        {
+            "source_id": 7,
+            "target_id": 2,
+            "weight": 0.18
+        },
+        {
+            "source_id": 6,
+            "target_id": 10,
+            "weight": 0.12
+        },
+        {
+            "source_id": 10,
+            "target_id": 4,
+            "weight": -0.35
+        },
+        {
+            "source_id": 10,
+            "target_id": 5,
+            "weight": -0.35
+        },
+        {
+            "source_id": 10,
+            "target_id": 6,
+            "weight": -0.35
+        },
+        {
+            "source_id": 2,
+            "target_id": 4,
+            "weight": -0.22
+        },
+        {
+            "source_id": 2,
+            "target_id": 5,
+            "weight": -0.22
+        },
+        {
+            "source_id": 8,
+            "target_id": 2,
+            "weight": 0.12
+        },
+        {
+            "source_id": 9,
+            "target_id": 1,
+            "weight": 0.12
+        },
+        {
+            "source_id": 0,
+            "target_id": 1,
+            "weight": -0.12
+        },
+        {
+            "source_id": 2,
+            "target_id": 3,
+            "weight": -0.12
+        },
+        {
+            "source_id": 4,
+            "target_id": 5,
+            "weight": -0.10
+        },
+        {
+            "source_id": 5,
+            "target_id": 4,
+            "weight": -0.10
+        },
+        {
+            "source_id": 6,
+            "target_id": 4,
+            "weight": 0.10
+        },
+        {
+            "source_id": 6,
+            "target_id": 5,
+            "weight": 0.10
+        },
+        {
+            "source_id": 3,
+            "target_id": 7,
+            "weight": 0.12
+        },
+        {
+            "source_id": 7,
+            "target_id": 4,
+            "weight": 0.10
+        },
+        {
+            "source_id": 3,
+            "target_id": 6,
+            "weight": 0.10
+        },
+        {
+            "source_id": 11,
+            "target_id": 10,
+            "weight": -0.25
+        },
+        {
+            "source_id": 11,
+            "target_id": 6,
+            "weight": -0.20
+        },
+        {
+            "source_id": 5,
+            "target_id": 0,
+            "weight": 0.10
+        },
+        {
+            "source_id": 8,
+            "target_id": 0,
+            "weight": 0.10
+        },
+        {
+            "source_id": 9,
+            "target_id": 0,
+            "weight": 0.10
+        }
+    ],
+    "rhythmogram_matrix": {
+        "enabled": true,
+        "scale": 5.0,
+        "filter_gains": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+        ]
+    },
+    "quantization": {
+        "enabled": true,
+        "grid_resolution": "sixteenth_note",
+        "quantization_amount": 0.65,
+        "swing_factor": 0.60,
+        "bpm": 112.0
+    }
+}

--- a/src/GUI.cpp
+++ b/src/GUI.cpp
@@ -282,11 +282,16 @@ void GUI::createNeuronSliders() {
     for (auto& combo : activationFunctionCombos) {
         slidersPanel->remove(combo);
     }
+    // Remove sample buttons if any
+    for (auto& btn : neuronSampleButtons) {
+        slidersPanel->remove(btn);
+    }
     
     neuronSliders.clear();
     neuronLabels.clear();
     neuronValueLabels.clear();
     activationFunctionCombos.clear();
+    neuronSampleButtons.clear();
     
     const auto& neurons = network->getNeurons();
     // Always start neuron sliders at a consistent position (not dependent on connection count)
@@ -373,7 +378,44 @@ void GUI::createNeuronSliders() {
         funcLabel->setTextSize(9);
         funcLabel->getRenderer()->setTextColor(tgui::Color::Green);
         slidersPanel->add(funcLabel);
-        
+
+        // Create sample selection button to the right of the function combo
+        std::string sampleFile = neuron->getSampleFilePath();
+        std::string sampleLabelText = "(no sample)";
+        if (!sampleFile.empty()) {
+            try {
+                sampleLabelText = std::filesystem::path(sampleFile).filename().string();
+            } catch (...) {
+                sampleLabelText = "(no sample)";
+            }
+        }
+
+        // Truncate long filenames to avoid UI overlap
+        std::string displayLabel = sampleLabelText;
+        const size_t maxLabelLen = 12;
+        if (displayLabel.size() > maxLabelLen) {
+            displayLabel = displayLabel.substr(0, maxLabelLen - 3) + "...";
+        }
+
+        auto sampleButton = tgui::Button::create(displayLabel);
+        // Position sample button to the right of the function combo but left of connection controls
+        // Func combo is at x=40 width=120 -> ends at 160. Connection column begins at ~215.
+        // Use a small button in the gap (x=165..215)
+        float sampleBtnX = 165.0f;
+        sampleButton->setPosition(sampleBtnX, yPos); // align with function combo row
+        sampleButton->setSize(50, 18);
+        sampleButton->setTextSize(9);
+        sampleButton->getRenderer()->setBackgroundColor(tgui::Color(70, 70, 70));
+        sampleButton->getRenderer()->setTextColor(tgui::Color::White);
+
+        // Capture index for the callback
+        sampleButton->onPress([this, i]() {
+            this->showChangeSampleDialog(i);
+        });
+
+        slidersPanel->add(sampleButton);
+        neuronSampleButtons.push_back(sampleButton);
+
         yPos += 22.0f; // Extra spacing after each neuron's controls
     }
     
@@ -1138,6 +1180,163 @@ void GUI::showAddNeuronDialog() {
     });
     dialog->add(cancelButton);
     
+    gui->add(dialog);
+}
+
+void GUI::showChangeSampleDialog(size_t neuronIndex) {
+    if (!network) return;
+
+    if (neuronIndex >= network->getNeuronCount()) return;
+
+    Neuron* neuron = network->getNeuron(neuronIndex);
+    if (!neuron) return;
+
+    // Create dialog window for changing sample
+    auto dialog = tgui::ChildWindow::create("Change Neuron Sample");
+    dialog->setSize(420, 360);
+    dialog->setPosition("50% - 210", "50% - 180");
+    dialog->getRenderer()->setTitleBarHeight(30);
+    dialog->getRenderer()->setBackgroundColor(tgui::Color(40, 40, 40, 240));
+
+    auto dirLabel = tgui::Label::create("Sample Directory:");
+    dirLabel->setPosition(10, 40);
+    dirLabel->setSize(150, 25);
+    dirLabel->getRenderer()->setTextColor(tgui::Color::White);
+    dialog->add(dirLabel);
+
+    auto dirComboBox = tgui::ComboBox::create();
+    dirComboBox->setPosition(10, 70);
+    dirComboBox->setSize(200, 25);
+    dialog->add(dirComboBox, "dirComboBox");
+
+    auto fileLabel = tgui::Label::create("Sample File:");
+    fileLabel->setPosition(10, 110);
+    fileLabel->setSize(150, 25);
+    dialog->add(fileLabel);
+
+    auto fileListBox = tgui::ListBox::create();
+    fileListBox->setPosition(10, 140);
+    fileListBox->setSize(400, 160);
+    dialog->add(fileListBox, "fileListBox");
+
+    // Populate directories
+    auto sampleDirs = getAllSampleDirectories();
+    for (const auto& d : sampleDirs) dirComboBox->addItem(d);
+    if (!sampleDirs.empty()) dirComboBox->setSelectedItem(sampleDirs[0]);
+
+    // Update file list when directory changes
+    dirComboBox->onItemSelect([=]() {
+        auto selectedDir = dirComboBox->getSelectedItem();
+        if (!selectedDir.empty()) {
+            fileListBox->removeAllItems();
+            auto files = getSampleFiles("samples/" + selectedDir.toStdString());
+            for (const auto& file : files) fileListBox->addItem(file);
+        }
+    });
+
+    // Initialize file list with first directory
+    if (!sampleDirs.empty()) {
+        auto files = getSampleFiles("samples/" + sampleDirs[0]);
+        for (const auto& file : files) fileListBox->addItem(file);
+    }
+
+    // Pre-select current file if known
+    std::string curPath = neuron->getSampleFilePath();
+    if (!curPath.empty()) {
+        try {
+            auto p = std::filesystem::path(curPath);
+            auto parent = p.parent_path().filename().string();
+            auto fname = p.filename().string();
+            if (!parent.empty()) {
+                dirComboBox->setSelectedItem(parent);
+                fileListBox->removeAllItems();
+                auto files = getSampleFiles("samples/" + parent);
+                for (const auto& file : files) fileListBox->addItem(file);
+                // Try to pre-select matching file in the list if available.
+                // TGUI ListBox selection API varies between versions; leave unselected if method not present.
+                (void)fname; // silence unused variable warning when selection is skipped
+            }
+        } catch (...) {
+            // ignore
+        }
+    }
+
+    // Buttons
+    auto changeButton = tgui::Button::create("Change Sample");
+    changeButton->setPosition(10, 310);
+    changeButton->setSize(140, 30);
+    changeButton->onPress([=]() {
+        auto selectedDir = dirComboBox->getSelectedItem();
+        auto selectedFile = fileListBox->getSelectedItem();
+
+        if (selectedDir.empty() || selectedFile.empty()) return;
+
+        std::string fullPath = "samples/" + selectedDir.toStdString() + "/" + selectedFile.toStdString();
+
+        if (!audioManager) {
+            std::cerr << "No AudioManager available to load sample" << std::endl;
+            dialog->close();
+            return;
+        }
+
+        int assignedIndex = neuron->getSampleIndex();
+        if (assignedIndex <= 0) {
+            // Provide a default mapping if neuron doesn't have an index
+            assignedIndex = static_cast<int>(neuronIndex) + 1;
+            neuron->setSampleIndex(assignedIndex);
+        }
+
+        if (!audioManager->loadSampleFromPath(assignedIndex, fullPath)) {
+            std::cerr << "Failed to load sample: " << fullPath << std::endl;
+            // Show small error dialog
+            auto err = tgui::ChildWindow::create("Error");
+            err->setSize(300, 120);
+            err->setPosition("50% - 150", "50% - 60");
+            auto msg = tgui::Label::create("Failed to load sample file: " + selectedFile.toStdString());
+            msg->setPosition(10, 20);
+            msg->setSize(280, 60);
+            err->add(msg);
+            auto ok = tgui::Button::create("OK");
+            ok->setPosition(100, 70);
+            ok->setSize(100, 30);
+            ok->onPress([err]() { err->close(); });
+            err->add(ok);
+            gui->add(err);
+            return;
+        }
+
+        // Update neuron's sample file path
+        neuron->setSampleFilePath(fullPath);
+
+        // Update sample button text to show filename
+        if (neuronIndex < neuronSampleButtons.size()) {
+            try {
+                std::string label = std::filesystem::path(fullPath).filename().string();
+                // Truncate long filenames to fit the small button
+                const size_t maxLabelLen = 12;
+                std::string display = label;
+                if (display.size() > maxLabelLen) display = display.substr(0, maxLabelLen - 3) + "...";
+                neuronSampleButtons[neuronIndex]->setText(display);
+            } catch (...) {
+                std::string display = selectedFile.toStdString();
+                const size_t maxLabelLen = 12;
+                if (display.size() > maxLabelLen) display = display.substr(0, maxLabelLen - 3) + "...";
+                neuronSampleButtons[neuronIndex]->setText(display);
+            }
+        }
+
+        std::cout << "Neuron " << neuronIndex << " sample changed to " << fullPath << std::endl;
+
+        dialog->close();
+    });
+    dialog->add(changeButton);
+
+    auto cancelButton = tgui::Button::create("Cancel");
+    cancelButton->setPosition(160, 310);
+    cancelButton->setSize(100, 30);
+    cancelButton->onPress([=]() { dialog->close(); });
+    dialog->add(cancelButton);
+
     gui->add(dialog);
 }
 

--- a/src/GUI.cpp
+++ b/src/GUI.cpp
@@ -43,7 +43,24 @@ void GUI::initialize() {
     
     // Initialize quantizer widget
     if (quantizerWidget) {
-        quantizerWidget->initialize(gui->getContainer());
+        // Create a popover ChildWindow for quantizer controls sized to fit the widget
+        quantizerWindow = tgui::ChildWindow::create("Quantization");
+        // Use a compact pixel size to better fit the quantizer content
+        quantizerWindow->setSize(360, 420);
+        // Position near top-center with a bit of padding
+        quantizerWindow->setPosition("50% - 180", "8%");
+        quantizerWindow->getRenderer()->setBackgroundColor(tgui::Color(40, 40, 40));
+        quantizerWindow->getRenderer()->setBorderColor(tgui::Color(80, 80, 80));
+        quantizerWindow->getRenderer()->setBorders(2);
+        quantizerWindow->setVisible(false); // start hidden; toggled by user
+        quantizerWindow->setResizable(false);
+        gui->add(quantizerWindow, "QuantizerWindow");
+
+        // Initialize the quantizer widget inside the child window
+        quantizerWidget->initialize(quantizerWindow);
+        // Make sure the quantizer main panel is centered and sized to fit nicely
+        quantizerWidget->setPosition(20.0f, 20.0f, 320.0f, 380.0f);
+
         // Initialize quantizer BPM to match default BPM (120.0)
         updateQuantizerBPM(120.0f);
     }
@@ -547,7 +564,7 @@ void GUI::refreshConnectionMatrix() {
     }
     
     // Only recreate the panel if it doesn't exist or if the number of neurons changed
-    if (!connectionMatrixPanel || !network || !network->getRhythmInterpreter()) {
+    if (!connectionMatrixWindow || !network || !network->getRhythmInterpreter()) {
         createConnectionMatrixPanel();
         return;
     }
@@ -1897,11 +1914,12 @@ void GUI::showExternalRecordingDialog() {
     gui->add(dialog);
 }
 void GUI::createConnectionMatrixPanel() {
-    // Remove existing panel if it exists
-    if (connectionMatrixPanel) {
-        // Preserve current visibility state before removing panel
-        matrixVisible = connectionMatrixPanel->isVisible();
-        gui->remove(connectionMatrixPanel);
+    // Remove existing window if it exists
+    if (connectionMatrixWindow) {
+        // Preserve current visibility state before removing window
+        matrixVisible = connectionMatrixWindow->isVisible();
+        gui->remove(connectionMatrixWindow);
+        connectionMatrixWindow = nullptr;
         connectionMatrixPanel = nullptr;
         matrixToggleButtons.clear();
         matrixGainSliders.clear();
@@ -1938,21 +1956,29 @@ void GUI::createConnectionMatrixPanel() {
     
     // Create panel even if no neurons yet - it will show as empty but ready
     
-    // Create main matrix panel with scrolling capability
-    connectionMatrixPanel = tgui::ScrollablePanel::create();
-    connectionMatrixPanel->setPosition("60%", "20%");
-    connectionMatrixPanel->setSize("39%", "75%");
-    connectionMatrixPanel->getRenderer()->setBackgroundColor(tgui::Color(20, 20, 20, 200));
-    connectionMatrixPanel->getRenderer()->setBorderColor(tgui::Color(60, 60, 60));
-    connectionMatrixPanel->getRenderer()->setBorders(1);
-    connectionMatrixPanel->setVisible(matrixVisible);
-    
-    // Set content size to accommodate all filters, neurons, and control sliders (Scale + BPM + Tempo)
-    float contentWidth = std::max(350.0f, static_cast<float>(270 + numNeurons * 80 + 280)); // Space for sliders and controls (BeatRoot controls removed)
-    float contentHeight = std::max(550.0f, static_cast<float>(150 + numFilters * 60 + 150)); // Extra space for better spaced tempo controls
-    static_cast<tgui::ScrollablePanel*>(connectionMatrixPanel.get())->setContentSize(tgui::Vector2f(contentWidth, contentHeight));
-    
-    gui->add(connectionMatrixPanel, "ConnectionMatrixPanel");
+    // Create a popover ChildWindow to host the rhythmogram (non-transparent, centered)
+    connectionMatrixWindow = tgui::ChildWindow::create("Rhythmogram Mapping");
+    connectionMatrixWindow->setSize("90%", "75%");
+    connectionMatrixWindow->setPosition("50% - 45%", "50% - 37.5%");
+    // Make the window semi-transparent so the neuron visualization is visible beneath
+    connectionMatrixWindow->getRenderer()->setBackgroundColor(tgui::Color(20, 20, 20, 120));
+    connectionMatrixWindow->getRenderer()->setBorderColor(tgui::Color(80, 80, 80));
+    connectionMatrixWindow->getRenderer()->setBorders(2);
+    connectionMatrixWindow->setVisible(matrixVisible);
+
+    // Inner content panel - all existing matrix widgets will be added to this panel
+    connectionMatrixPanel = tgui::Panel::create();
+    connectionMatrixPanel->setPosition("0%", "0%");
+    connectionMatrixPanel->setSize("100%", "100%");
+    // Make inner panel transparent to allow underlying visualization to show through
+    connectionMatrixPanel->getRenderer()->setBackgroundColor(tgui::Color(0,0,0,0));
+    connectionMatrixWindow->add(connectionMatrixPanel);
+
+    gui->add(connectionMatrixWindow, "ConnectionMatrixPanel");
+
+    // Compute content size estimates (used for laying out controls inside the popover)
+    float contentWidth = std::max(350.0f, static_cast<float>(270 + numNeurons * 80 + 280)); // estimate
+    float contentHeight = std::max(550.0f, static_cast<float>(150 + numFilters * 60 + 150)); // estimate
     
     // Title label
     std::string title = numNeurons == 0 ? "🎛️ Rhythmogram Mapping (8×0) - Add neurons first" : 
@@ -2683,12 +2709,12 @@ void GUI::updateConnectionMatrix() {
 }
 
 void GUI::toggleMatrixVisibility() {
-    if (!connectionMatrixPanel) {
+    if (!connectionMatrixWindow) {
         return;
     }
-    
+
     matrixVisible = !matrixVisible;
-    connectionMatrixPanel->setVisible(matrixVisible);
+    connectionMatrixWindow->setVisible(matrixVisible);
     
     std::cout << "🎛️ Rhythmogram Mapping " << (matrixVisible ? "shown" : "hidden") 
               << " (press M to toggle)" << std::endl;
@@ -2701,7 +2727,14 @@ void GUI::forceMatrixUpdate() {
 }
 
 void GUI::toggleQuantizerVisibility() {
-    if (quantizerWidget) {
+    if (quantizerWindow) {
+        bool newState = !quantizerWindow->isVisible();
+        quantizerWindow->setVisible(newState);
+        // Also ensure the internal widget is visible when the window is shown
+        if (quantizerWidget) quantizerWidget->setVisible(newState);
+        std::cout << "🎵 Quantizer " << (newState ? "shown" : "hidden") << " (press Q to toggle)" << std::endl;
+    } else if (quantizerWidget) {
+        // Fallback: toggle internal widget visibility
         quantizerWidget->toggleVisibility();
         std::cout << "🎵 Quantizer " << (quantizerWidget->isVisible() ? "shown" : "hidden") 
                   << " (press Q to toggle)" << std::endl;

--- a/src/GUI.h
+++ b/src/GUI.h
@@ -50,6 +50,7 @@ private:
     std::vector<tgui::Label::Ptr> neuronLabels;
     std::vector<tgui::Label::Ptr> neuronValueLabels;
     std::vector<tgui::ComboBox::Ptr> activationFunctionCombos;
+    std::vector<tgui::Button::Ptr> neuronSampleButtons; // Button to change/select sample for each neuron
     tgui::Slider::Ptr activationIntervalSlider;
     tgui::Label::Ptr activationIntervalLabel;
     tgui::ComboBox::Ptr viewModeComboBox;
@@ -159,6 +160,7 @@ private:
     void onSliderChanged(size_t connectionIndex, float value);
     void onNeuronSliderChanged(size_t neuronIndex, float value);
     void onActivationFunctionChanged(size_t neuronIndex, const std::string& functionName);
+    void showChangeSampleDialog(size_t neuronIndex);
 
 public:
     GUI(tgui::Gui* tguiGui, sf::RenderWindow* renderWindow, NeuronNetwork* neuronNetwork, 

--- a/src/GUI.h
+++ b/src/GUI.h
@@ -75,7 +75,8 @@ private:
     // Frequency response visualization temporarily removed due to TGUI limitations
     
     // Connection matrix GUI (8 filters × N neurons)
-    tgui::ScrollablePanel::Ptr connectionMatrixPanel;
+    tgui::Panel::Ptr connectionMatrixPanel; // now a content panel hosted inside a ChildWindow
+    tgui::ChildWindow::Ptr connectionMatrixWindow; // popover window for rhythmogram (was full-width panel)
     tgui::Label::Ptr matrixTitleLabel;
     std::vector<std::vector<tgui::Button::Ptr>> matrixToggleButtons; // [filter][neuron]
     std::vector<std::vector<tgui::Slider::Ptr>> matrixGainSliders;   // [filter][neuron] 
@@ -112,6 +113,7 @@ private:
     // Quantization system
     std::unique_ptr<Quantizer> quantizer;        // Musical quantization engine
     std::unique_ptr<QuantizerWidget> quantizerWidget; // Quantization controls widget
+    tgui::ChildWindow::Ptr quantizerWindow; // popover window for quantizer controls
     float lastQuantizerBPM = -1.0f;             // Track last BPM to avoid unnecessary updates
     
     // Layout

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,32 +84,49 @@ private:
 #else
             bool eventConsumedByGUI = false;
 #endif
-            event.visit([&](const auto& e) {
-                using T = std::decay_t<decltype(e)>;
-                if constexpr (std::is_same_v<T, sf::Event::MouseButtonPressed>) {
-                    if (!eventConsumedByGUI && e.button == sf::Mouse::Button::Left) {
-                        handleMouseDrag(e.position.x, e.position.y);
+            // Use explicit type checks and getIf for SFML Event (works for SFML 3)
+            if (event.is<sf::Event::MouseButtonPressed>()) {
+                if (!eventConsumedByGUI) {
+                    if (const auto* e = event.getIf<sf::Event::MouseButtonPressed>()) {
+                        if (e->button == sf::Mouse::Button::Left) {
+                            handleMouseDrag(e->position.x, e->position.y);
+                        }
                     }
-                } else if constexpr (std::is_same_v<T, sf::Event::Closed>) {
-                    window.close();
-                } else if constexpr (std::is_same_v<T, sf::Event::MouseWheelScrolled>) {
-                    handleMouseScroll(e.delta);
-                } else if constexpr (std::is_same_v<T, sf::Event::MouseMoved>) {
-                    if (!eventConsumedByGUI) {
+                }
+            } else if (event.is<sf::Event::Closed>()) {
+                window.close();
+            } else if (event.is<sf::Event::MouseWheelScrolled>()) {
+                if (const auto* e = event.getIf<sf::Event::MouseWheelScrolled>()) {
+                    handleMouseScroll(e->delta);
+                }
+            } else if (event.is<sf::Event::MouseMoved>()) {
+                if (!eventConsumedByGUI) {
+                    if (const auto* e = event.getIf<sf::Event::MouseMoved>()) {
                         static int mouseEventCounter = 0;
                         if (++mouseEventCounter % 100 == 0) { // Print every 100th event to avoid spam
-                            std::cout << "🖱️ Mouse moved to (" << e.position.x << ", " << e.position.y << ")" << std::endl;
+                            std::cout << "🖱️ Mouse moved to (" << e->position.x << ", " << e->position.y << ")" << std::endl;
                         }
-                        visualizer.handleMouseMove(e.position.x, e.position.y);
+                        visualizer.handleMouseMove(e->position.x, e->position.y);
                     }
-                } else if constexpr (std::is_same_v<T, sf::Event::KeyPressed>) {
-                    if (!eventConsumedByGUI) {
-                        handleKeyPress(e.code);
-                    }
-                } else {
-                    // Ignore other events
                 }
-            });
+            } else if (event.is<sf::Event::KeyPressed>()) {
+                if (const auto* e = event.getIf<sf::Event::KeyPressed>()) {
+                    // Forward only application-level global shortcuts even if GUI consumed the event.
+                    // This avoids requiring a click on the visualization to use shortcuts while not
+                    // hijacking normal text input which GUI will typically consume.
+                    sf::Keyboard::Key code = e->code;
+                    bool isGlobalShortcut = (code == sf::Keyboard::Key::M) || (code == sf::Keyboard::Key::Q) ||
+                                            (code == sf::Keyboard::Key::Space) || (code == sf::Keyboard::Key::F) ||
+                                            (code >= sf::Keyboard::Key::Num1 && code <= sf::Keyboard::Key::Num9) ||
+                                            (code == sf::Keyboard::Key::S) || (code == sf::Keyboard::Key::L);
+
+                    if (!eventConsumedByGUI || isGlobalShortcut) {
+                        handleKeyPress(code);
+                    }
+                }
+            } else {
+                // Ignore other events
+            }
         }
     }
 private:


### PR DESCRIPTION
This pull request adds four new drum machine neural network presets in JSON format to the `presets/factory` directory. Each preset describes a different configuration of neurons, connections, and rhythm/quantization settings for generative drum synthesis. The main changes are the introduction of diverse network topologies for various drum machine use cases, ranging from compact and basic kits to more complex groove and fill generators.

**New Drum Machine Presets:**

* **General-purpose/generative networks:**
  - Added `pjs_drum_brain-v1.json`, a 16-neuron preset featuring kick, snare, hat, and FX roles, with groove links and inhibition for generative drum patterns.
  - Added `pjs_drum_brain_basic.json`, a 16-neuron preset using only basic drum kit slots (1–8), with multiple neurons per slot for groove variation.

* **Compact/kit-focused network:**
  - Added `pjs_drum_brain_4.json`, a compact 4-neuron preset for basic drum patterns using only sample slots 1–4 (kick, snare, hat, FX).

* **Performance/fill-focused network:**
  - Added `pjs_fill_machine.json`, a 16-neuron preset designed for drum fills and performance, with specific neuron roles for kicks, snares, hats, toms, cymbals, and fill chains.